### PR TITLE
[refactor] 블로그 생성 및 조회시 진행상황 정보를 추가하도록 수정 & 진행상황(Progress) 엔티티 및 관련 클래스 생성 / #38

### DIFF
--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/BlogDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/BlogDto.java
@@ -1,6 +1,8 @@
 package dev.woori.wooriLog.domain.blog.dto;
 
+import dev.woori.wooriLog.domain.blog.dto.request.ProgressDto;
 import dev.woori.wooriLog.domain.blog.entity.Blog;
+import dev.woori.wooriLog.domain.blog.entity.Progress;
 import dev.woori.wooriLog.domain.blog.enums.Category;
 import lombok.Builder;
 
@@ -8,24 +10,32 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record BlogPostDto(
+public record BlogDto(
         String title,
         List<String> tags,
         Category category,
         String document,
+        List<ProgressDto> progresses,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static BlogPostDto create(
+    public static BlogDto create(
             Blog blog
     ) {
-        return BlogPostDto.builder()
+        return BlogDto.builder()
                 .title(blog.getTitle())
                 .tags(blog.getTags())
                 .category(blog.getCategory())
                 .document(blog.getDocument())
+                .progresses(progressToDto(blog.getProgresses()))
                 .createdAt(blog.getCreatedAt())
                 .updatedAt(blog.getUpdatedAt())
                 .build();
+    }
+
+    public static List<ProgressDto> progressToDto(List<Progress> progresses) {
+        return progresses.stream()
+                .map(ProgressDto::create)
+                .toList();
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/BlogCreateReq.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/BlogCreateReq.java
@@ -23,6 +23,7 @@ public record BlogCreateReq(
         @NotNull
         List<String> tags,
 
+        @NotNull
         List<ProgressDto> progresses
 ) {
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/BlogCreateReq.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/BlogCreateReq.java
@@ -1,6 +1,8 @@
 package dev.woori.wooriLog.domain.blog.dto.request;
 
+import dev.woori.wooriLog.domain.blog.entity.Progress;
 import dev.woori.wooriLog.domain.blog.enums.Category;
+import dev.woori.wooriLog.domain.blog.enums.ProgressValue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -19,6 +21,8 @@ public record BlogCreateReq(
         Category category,
 
         @NotNull
-        List<String> tags
+        List<String> tags,
+
+        List<ProgressDto> progresses
 ) {
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/ProgressDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/request/ProgressDto.java
@@ -1,0 +1,15 @@
+package dev.woori.wooriLog.domain.blog.dto.request;
+
+import dev.woori.wooriLog.domain.blog.entity.Progress;
+import dev.woori.wooriLog.domain.blog.enums.ProgressValue;
+import lombok.Builder;
+
+@Builder
+public record ProgressDto(
+        ProgressValue progress,
+        String message
+) {
+    public static ProgressDto create(Progress progress) {
+        return new ProgressDto(progress.getProgress(), progress.getMessage());
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogDetailInfoRes.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogDetailInfoRes.java
@@ -1,18 +1,18 @@
 package dev.woori.wooriLog.domain.blog.dto.response;
 
-import dev.woori.wooriLog.domain.blog.dto.BlogPostDto;
+import dev.woori.wooriLog.domain.blog.dto.BlogDto;
 import dev.woori.wooriLog.domain.blog.dto.BlogProjectDto;
 import dev.woori.wooriLog.domain.member.dto.MemberInfoDto;
 import lombok.Builder;
 
 @Builder
 public record BlogDetailInfoRes(
-        BlogPostDto post,
+        BlogDto post,
         BlogProjectDto project,
         MemberInfoDto author
 ) {
     public static BlogDetailInfoRes create(
-            BlogPostDto post,
+            BlogDto post,
             BlogProjectDto project,
             MemberInfoDto author
     ) {

--- a/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
@@ -44,7 +44,11 @@ public class Blog extends BaseEntity {
     @CollectionTable(name = "tags", joinColumns = @JoinColumn(name = "blog_id"))
     private List<String> tags;
 
-    public static Blog create(Project project, Member member, BlogCreateReq request) {
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "blog_id")
+    private List<Progress> progresses;
+
+    public static Blog create(Project project, Member member, BlogCreateReq request, List<Progress> progresses) {
         return Blog.builder()
                 .document(request.document())
                 .title(request.title())
@@ -52,6 +56,7 @@ public class Blog extends BaseEntity {
                 .member(member)
                 .category(request.category())
                 .tags(request.tags())
+                .progresses(progresses)
                 .build();
     }
 

--- a/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
@@ -8,6 +8,7 @@ import dev.woori.wooriLog.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -50,18 +51,30 @@ public class Blog extends BaseEntity {
             cascade = CascadeType.ALL,
             orphanRemoval = true
     )
-    private List<Progress> progresses;
+    @Builder.Default
+    private List<Progress> progresses = new ArrayList<>();
 
     public static Blog create(Project project, Member member, BlogCreateReq request, List<Progress> progresses) {
-        return Blog.builder()
+        Blog blog = Blog.builder()
                 .document(request.document())
                 .title(request.title())
                 .project(project)
                 .member(member)
                 .category(request.category())
                 .tags(request.tags())
-                .progresses(progresses)
                 .build();
+        blog.addProgresses(progresses);
+        return blog;
+    }
+
+    private void addProgress(Progress p) {
+        this.progresses.add(p);
+        p.setBlog(this);
+    }
+
+    public void addProgresses(List<Progress> progresses) {
+        if (progresses == null) return;
+        for (Progress p : progresses) addProgress(p);
     }
 
     // id가 커밋 후에 저장되기 때문에 일단 커밋한 후 idx를 업데이트

--- a/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/entity/Blog.java
@@ -44,8 +44,12 @@ public class Blog extends BaseEntity {
     @CollectionTable(name = "tags", joinColumns = @JoinColumn(name = "blog_id"))
     private List<String> tags;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "blog_id")
+    @OneToMany(
+            mappedBy = "blog",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
     private List<Progress> progresses;
 
     public static Blog create(Project project, Member member, BlogCreateReq request, List<Progress> progresses) {

--- a/src/main/java/dev/woori/wooriLog/domain/blog/entity/Progress.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/entity/Progress.java
@@ -1,0 +1,36 @@
+package dev.woori.wooriLog.domain.blog.entity;
+
+import dev.woori.wooriLog.domain.blog.dto.request.ProgressDto;
+import dev.woori.wooriLog.domain.blog.enums.ProgressValue;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Progress {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "progress_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ProgressValue progress;
+
+    private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blog_id")
+    private Blog blog;
+
+    private Progress(ProgressValue progress, String message) {
+        this.progress = progress;
+        this.message = message;
+    }
+
+    public static Progress create(ProgressDto dto) {
+        return new Progress(dto.progress(), dto.message());
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/blog/entity/Progress.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/entity/Progress.java
@@ -33,4 +33,8 @@ public class Progress {
     public static Progress create(ProgressDto dto) {
         return new Progress(dto.progress(), dto.message());
     }
+
+    public void setBlog(Blog blog) {
+        this.blog = blog;
+    }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/enums/ProgressValue.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/enums/ProgressValue.java
@@ -1,0 +1,32 @@
+package dev.woori.wooriLog.domain.blog.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ProgressValue {
+    SITUATION("상황"),
+    CONCERN("고민"),
+    ACTION("실행"),
+    REFLECTION("회고/성장");
+
+    private final String value;
+
+    ProgressValue(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ProgressValue category(String value) {
+        for (ProgressValue category : ProgressValue.values()) {
+            if (category.value.equals(value) || category.name().equals(value)) {
+                return category;
+            }
+        }
+        throw new IllegalArgumentException("정의되지 않은 값입니다." + value);
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/blog/enums/ProgressValue.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/enums/ProgressValue.java
@@ -21,7 +21,7 @@ public enum ProgressValue {
     }
 
     @JsonCreator
-    public static ProgressValue category(String value) {
+    public static ProgressValue fromValue(String value) {
         for (ProgressValue category : ProgressValue.values()) {
             if (category.value.equals(value) || category.name().equals(value)) {
                 return category;

--- a/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
@@ -3,6 +3,8 @@ package dev.woori.wooriLog.domain.blog.repository;
 import dev.woori.wooriLog.domain.blog.entity.Blog;
 import dev.woori.wooriLog.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +15,7 @@ public interface BlogRepository extends JpaRepository<Blog, Long> {
     Optional<Blog> findById(Long blogId);
 
     List<Blog> findAllByProject(Project project);
+
+    @Query("SELECT b FROM Blog b JOIN FETCH b.member JOIN FETCH b.project LEFT JOIN FETCH b.progresses WHERE b.id = :id")
+    Optional<Blog> findBlogByIdWithDetails(@Param("id") Long id);
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/repository/ProgressRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/repository/ProgressRepository.java
@@ -1,0 +1,7 @@
+package dev.woori.wooriLog.domain.blog.repository;
+
+import dev.woori.wooriLog.domain.blog.entity.Progress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProgressRepository extends JpaRepository<Progress, Long> {
+}

--- a/src/main/java/dev/woori/wooriLog/domain/blog/repository/ProgressRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/repository/ProgressRepository.java
@@ -2,6 +2,8 @@ package dev.woori.wooriLog.domain.blog.repository;
 
 import dev.woori.wooriLog.domain.blog.entity.Progress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProgressRepository extends JpaRepository<Progress, Long> {
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -70,7 +70,8 @@ public class BlogService {
      */
     @Transactional
     public BlogDetailInfoRes getBlogInfo(Long postId) {
-        Blog blog = blogRepository.findById(postId).orElseThrow(IllegalArgumentException::new);
+        Blog blog = blogRepository.findBlogByIdWithDetails(postId)
+                .orElseThrow(IllegalArgumentException::new);
         Project project = blog.getProject();
         Member author = blog.getMember();
         return BlogDetailInfoRes.create(

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -5,7 +5,9 @@ import dev.woori.wooriLog.domain.blog.dto.*;
 import dev.woori.wooriLog.domain.blog.dto.request.BlogCreateReq;
 import dev.woori.wooriLog.domain.blog.dto.response.BlogDetailInfoRes;
 import dev.woori.wooriLog.domain.blog.entity.Blog;
+import dev.woori.wooriLog.domain.blog.entity.Progress;
 import dev.woori.wooriLog.domain.blog.repository.BlogRepository;
+import dev.woori.wooriLog.domain.blog.repository.ProgressRepository;
 import dev.woori.wooriLog.domain.member.dto.MemberInfoDto;
 import dev.woori.wooriLog.domain.member.entity.Member;
 import dev.woori.wooriLog.domain.member.repository.MemberRepository;
@@ -28,6 +30,7 @@ public class BlogService {
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final ProgressRepository progressRepository;
 
     /**
      * 프로젝트 ID, 유저ID, Request의 새 문서 데이터를 받아 DB에 저장합니다.
@@ -38,9 +41,24 @@ public class BlogService {
      */
     @Transactional
     public Long createBlog(Long projectId, Long userId, BlogCreateReq request) {
-        Project project = projectRepository.findById(projectId).orElseThrow(IllegalArgumentException::new);
-        Member member = memberRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
-        return blogRepository.save(Blog.create(project, member, request)).getId();
+        // 프로젝트-멤버 관계 조회
+        ProjectMember projectMember = projectMemberRepository.findWithMemberAndProjectByIds(projectId, userId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        // Progress Entity 생성
+        List<Progress> progresses = request.progresses().stream()
+                .map(Progress::create)
+                .toList();
+
+        // Blog Entity 생성
+        Blog createdBlog = Blog.create(
+                projectMember.getProject(),
+                projectMember.getMember(),
+                request, progresses
+        );
+
+        blogRepository.save(createdBlog);
+        return createdBlog.getId();
     }
 
     /**
@@ -54,11 +72,11 @@ public class BlogService {
     public BlogDetailInfoRes getBlogInfo(Long postId) {
         Blog blog = blogRepository.findById(postId).orElseThrow(IllegalArgumentException::new);
         Project project = blog.getProject();
-        Member member = blog.getMember();
+        Member author = blog.getMember();
         return BlogDetailInfoRes.create(
-                BlogPostDto.create(blog),
-                createBlogProjectDTO(project),
-                MemberInfoDto.create(member)
+                BlogDto.create(blog),
+                createBlogProjectDTO(project, author),
+                MemberInfoDto.create(author)
         );
     }
 
@@ -68,10 +86,12 @@ public class BlogService {
      * @param project 열람할 글을 작성한 프로젝트의 엔티티
      * @return BlogProjectDto: 열람할 글을 작성한 프로젝트의 DTO
      */
-    private BlogProjectDto createBlogProjectDTO(Project project) {
-        List<ProjectMember> projectMember = projectMemberRepository.findByProject(project);
+    private BlogProjectDto createBlogProjectDTO(Project project, Member author) {
+        List<ProjectMember> projectMember = projectMemberRepository.findWithProjectAndNotAuthorByIds(project, author);
 
-        List<MemberInfoDto> memberList = projectMember.stream().map(pm -> MemberInfoDto.create(pm.getMember())).toList();
+        List<MemberInfoDto> memberList = projectMember.stream()
+                .map(pm -> MemberInfoDto.create(pm.getMember()))
+                .toList();
 
         return BlogProjectDto.create(
                 project.getProjectName(),

--- a/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
@@ -19,4 +20,10 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
     @Query("SELECT pm.project FROM ProjectMember pm WHERE pm.member = :member")
     List<Project> findProjectsByMember(@Param("member") Member member);
+
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE p.id = :projectId AND m.id = :memberId")
+    Optional<ProjectMember> findWithMemberAndProjectByIds(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
+
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE p = :project AND m != :author")
+    List<ProjectMember> findWithProjectAndNotAuthorByIds(@Param("project") Project project, @Param("author") Member author);
 }


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #38 
## 작업 내용 📋

- 블로그 글의 진행상황을 나타내는 엔티티 추가 (Progress)
- Progress 관련 클래스 추가 (Repository, DTO)
- 블로그 생성 및 조회시 Progress 엔티티를 추가하도록 수정
- 블로그 관련 서비스 로직에서 쿼리 수정을 통한 성능 개선 
-> 프로젝트 및 회원 조회시 ProjectMember 엔티티를 Fetch Join을 통해 조회하여 쿼리 횟수 감소
 
## 스크린샷 (선택) 📸
 
## 기타 🔥

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
