### PR TITLE
[feat] 회원 정보 조회 및 프로필 페이지에 필요한 정보 조회 api 구현

### DIFF
--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/BlogSummaryDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/BlogSummaryDto.java
@@ -1,0 +1,28 @@
+package dev.woori.wooriLog.domain.blog.dto;
+
+import dev.woori.wooriLog.domain.blog.entity.Blog;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record BlogSummaryDto(
+        Long blogId,
+        String title,
+        List<String> tags,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static BlogSummaryDto create(
+            Blog blog
+    ) {
+        return BlogSummaryDto.builder()
+                .blogId(blog.getId())
+                .title(blog.getTitle())
+                .tags(blog.getTags())
+                .createdAt(blog.getCreatedAt())
+                .updatedAt(blog.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface BlogRepository extends JpaRepository<Blog, Long> {
     Optional<Blog> findById(Long blogId);
 
+    @Query("SELECT b FROM Blog b LEFT JOIN FETCH b.tags WHERE b.member.id = :memberId")
     List<Blog> findByMemberId(Long memberId);
 
     List<Blog> findAllByProject(Project project);

--- a/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/repository/BlogRepository.java
@@ -12,5 +12,7 @@ import java.util.Optional;
 public interface BlogRepository extends JpaRepository<Blog, Long> {
     Optional<Blog> findById(Long blogId);
 
+    List<Blog> findByMemberId(Long memberId);
+
     List<Blog> findAllByProject(Project project);
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -25,8 +25,8 @@ public class MemberController {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMemberById(userId));
     }
 
-    @GetMapping("/members/profile/{userId}")
-    public ResponseEntity<?> getProfileInfoById(@PathVariable Long userId) {
+    @GetMapping("/members/profile")
+    public ResponseEntity<?> getProfileInfoById(@UserId Long userId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findProfileInfoById(userId));
     }
 

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -25,8 +25,8 @@ public class MemberController {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMemberById(userId));
     }
 
-    @GetMapping("/members/profile")
-    public ResponseEntity<?> getProfileInfoById(@UserId Long userId) {
+    @GetMapping("/members/profile/{userId}")
+    public ResponseEntity<?> getProfileInfoById(@PathVariable Long userId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findProfileInfoById(userId));
     }
 

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -18,4 +18,16 @@ public class MemberController {
     public ResponseEntity<?> getMembersInfoByEmail(@RequestParam String email) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersByEmail(email));
     }
+
+    // 개발용
+    @GetMapping("/members/{userId}")
+    public ResponseEntity<?> getMembersInfoById(@RequestParam Long userId) {
+        return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersById(userId));
+    }
+
+    // 운영용
+//    @GetMapping("/members")
+//    public ResponseEntity<?> getMembersInfoById(@UserId Long userId) {
+//        return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersById(id));
+//    }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -25,4 +25,9 @@ public class MemberController {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMemberById(userId));
     }
 
+    @GetMapping("/members/profile")
+    public ResponseEntity<?> getProfileInfoById(@UserId Long userId) {
+        return ApiResponseUtil.success(SuccessCode.OK, memberService.findProfileInfoById(userId));
+    }
+
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -21,7 +21,8 @@ public class MemberController {
     }
 
     @GetMapping("/members")
-    public ResponseEntity<?> getMembersInfoById(@UserId Long userId) {
-        return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersById(userId));
+    public ResponseEntity<?> getMemberInfoById(@UserId Long userId) {
+        return ApiResponseUtil.success(SuccessCode.OK, memberService.findMemberById(userId));
     }
+
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package dev.woori.wooriLog.domain.member.controller;
 
 import dev.woori.wooriLog.domain.member.service.MemberService;
+import dev.woori.wooriLog.global.resolver.UserId;
 import dev.woori.wooriLog.global.response.ApiResponseUtil;
 import dev.woori.wooriLog.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +20,8 @@ public class MemberController {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersByEmail(email));
     }
 
-    // 개발용
-    @GetMapping("/members/{userId}")
-    public ResponseEntity<?> getMembersInfoById(@RequestParam Long userId) {
+    @GetMapping("/members")
+    public ResponseEntity<?> getMembersInfoById(@UserId Long userId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersById(userId));
     }
-
-    // 운영용
-//    @GetMapping("/members")
-//    public ResponseEntity<?> getMembersInfoById(@UserId Long userId) {
-//        return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersById(id));
-//    }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
@@ -1,0 +1,38 @@
+package dev.woori.wooriLog.domain.member.dto;
+
+import dev.woori.wooriLog.domain.blog.dto.BlogInfoDto;
+import dev.woori.wooriLog.domain.blog.dto.BlogSummaryDto;
+import dev.woori.wooriLog.domain.blog.entity.Blog;
+import dev.woori.wooriLog.domain.member.entity.Member;
+import dev.woori.wooriLog.domain.project.dto.ProjectSummaryDto;
+import dev.woori.wooriLog.domain.project.entity.Project;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProfileDto(
+        Long userId,
+        String email,
+        String name,
+        String introduce,
+        List<BlogSummaryDto> blogList,
+        List<ProjectSummaryDto> projectList
+) {
+    public static ProfileDto create(Member member, List<Blog> blogs, List<Project> projects) {
+        List<BlogSummaryDto> blogSummaryDtos = blogs.stream()
+                .map(BlogSummaryDto::create)
+                .toList();
+        List<ProjectSummaryDto> projectSummaryDtos = projects.stream()
+                .map(ProjectSummaryDto::create)
+                .toList();
+        return ProfileDto.builder()
+                .userId(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .introduce(member.getIntroduce())
+                .blogList(blogSummaryDtos)
+                .projectList(projectSummaryDtos)
+                .build();
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
@@ -1,6 +1,5 @@
 package dev.woori.wooriLog.domain.member.dto;
 
-import dev.woori.wooriLog.domain.blog.dto.BlogInfoDto;
 import dev.woori.wooriLog.domain.blog.dto.BlogSummaryDto;
 import dev.woori.wooriLog.domain.blog.entity.Blog;
 import dev.woori.wooriLog.domain.member.entity.Member;

--- a/src/main/java/dev/woori/wooriLog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/repository/MemberRepository.java
@@ -12,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderAndSocialId(String provider, String socialId);
 
     Optional<Member> findByIdAndEmail(Long id, String email);
+
+    Optional<Member> findById(Long id);
     
     List<Member> findAllByEmailContaining(String email);
 

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package dev.woori.wooriLog.domain.member.service;
 import dev.woori.wooriLog.domain.member.dto.MemberInfoDto;
 import dev.woori.wooriLog.domain.member.entity.Member;
 import dev.woori.wooriLog.domain.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,5 +25,15 @@ public class MemberService {
     public List<MemberInfoDto> findMembersByEmail(String email) {
         List<Member> members = memberRepository.findAllByEmailContaining(email);
         return members.stream().map(MemberInfoDto::create).toList();
+    }
+
+    /**
+     * 파라미터로 넘어온 id를 갖는 회원을 반환
+     * @param userId 회원 id
+     * @return MemberDTO 회원 정보를 담은 객체
+     */
+    public MemberInfoDto findMembersById(Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        return  MemberInfoDto.create(member);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
      * @return MemberDTO 회원 정보를 담은 객체
      */
     public MemberInfoDto findMemberById(Long userId) {
-        Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        Member member = memberRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
         return  MemberInfoDto.create(member);
     }
 

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import dev.woori.wooriLog.domain.member.dto.ProfileDto;
 import dev.woori.wooriLog.domain.member.entity.Member;
 import dev.woori.wooriLog.domain.member.repository.MemberRepository;
 import dev.woori.wooriLog.domain.project.entity.Project;
+import dev.woori.wooriLog.domain.project.entity.ProjectMember;
 import dev.woori.wooriLog.domain.project.repository.ProjectMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -50,9 +51,10 @@ public class MemberService {
      * @return ProfileDto 회원 정보 + 간략한 블로그 정보 + 간략한 프로젝트 정보를 담은 객체
      */
     public ProfileDto findProfileInfoById(Long userId) {
-        Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         List<Blog> blogs = blogRepository.findByMemberId(userId);
-        List<Project> projects = projectMemberRepository.findByMemberId(userId);
+        List<ProjectMember> projectMembers = projectMemberRepository.findByMemberId(userId);
+        Member member = projectMembers.get(0).getMember();
+        List<Project> projects = projectMembers.stream().map(ProjectMember::getProject).toList();
         return ProfileDto.create(member, blogs, projects);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -51,10 +51,9 @@ public class MemberService {
      * @return ProfileDto 회원 정보 + 간략한 블로그 정보 + 간략한 프로젝트 정보를 담은 객체
      */
     public ProfileDto findProfileInfoById(Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
         List<Blog> blogs = blogRepository.findByMemberId(userId);
-        List<ProjectMember> projectMembers = projectMemberRepository.findByMemberId(userId);
-        Member member = projectMembers.get(0).getMember();
-        List<Project> projects = projectMembers.stream().map(ProjectMember::getProject).toList();
+        List<Project> projects = projectMemberRepository.findByMemberId(userId);
         return ProfileDto.create(member, blogs, projects);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -1,8 +1,13 @@
 package dev.woori.wooriLog.domain.member.service;
 
+import dev.woori.wooriLog.domain.blog.entity.Blog;
+import dev.woori.wooriLog.domain.blog.repository.BlogRepository;
 import dev.woori.wooriLog.domain.member.dto.MemberInfoDto;
+import dev.woori.wooriLog.domain.member.dto.ProfileDto;
 import dev.woori.wooriLog.domain.member.entity.Member;
 import dev.woori.wooriLog.domain.member.repository.MemberRepository;
+import dev.woori.wooriLog.domain.project.entity.Project;
+import dev.woori.wooriLog.domain.project.repository.ProjectMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +21,8 @@ import java.util.List;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final BlogRepository blogRepository;
+    private final ProjectMemberRepository projectMemberRepository;
 
     /**
      * 파라미터로 넘어온 email을 포함하는 이메일을 가진 유저들을 반환
@@ -35,5 +42,17 @@ public class MemberService {
     public MemberInfoDto findMemberById(Long userId) {
         Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         return  MemberInfoDto.create(member);
+    }
+
+    /**
+     * 파라미터로 넘어온 userId를 통해 프로필 페이지에 필요한 정보를 조회
+     * @param userId 회원 id
+     * @return ProfileDto 회원 정보 + 간략한 블로그 정보 + 간략한 프로젝트 정보를 담은 객체
+     */
+    public ProfileDto findProfileInfoById(Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        List<Blog> blogs = blogRepository.findByMemberId(userId);
+        List<Project> projects = projectMemberRepository.findByMemberId(userId);
+        return ProfileDto.create(member, blogs, projects);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/service/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
      * @param userId 회원 id
      * @return MemberDTO 회원 정보를 담은 객체
      */
-    public MemberInfoDto findMembersById(Long userId) {
+    public MemberInfoDto findMemberById(Long userId) {
         Member member = memberRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         return  MemberInfoDto.create(member);
     }

--- a/src/main/java/dev/woori/wooriLog/domain/project/dto/ProjectSummaryDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/dto/ProjectSummaryDto.java
@@ -1,0 +1,21 @@
+package dev.woori.wooriLog.domain.project.dto;
+
+import dev.woori.wooriLog.domain.project.entity.Project;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProjectSummaryDto(
+        Long projectId,
+        String projectName,
+        List<String> techStack
+) {
+    public static ProjectSummaryDto create(Project project) {
+        return ProjectSummaryDto.builder()
+                .projectId(project.getId())
+                .projectName(project.getProjectName())
+                .techStack(project.getTechStack())
+                .build();
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
@@ -27,6 +27,6 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE p = :project AND m != :author")
     List<ProjectMember> findWithProjectAndNotAuthorByIds(@Param("project") Project project, @Param("author") Member author);
 
-    @Query("SELECT pm.project FROM ProjectMember pm WHERE pm.member.id = :memberId")
-    List<Project> findByMemberId(@Param("memberId") Long memberId);
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE pm.member.id = :memberId")
+    List<ProjectMember> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
@@ -19,4 +19,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
     @Query("SELECT pm.project FROM ProjectMember pm WHERE pm.member = :member")
     List<Project> findProjectsByMember(@Param("member") Member member);
+
+    @Query("SELECT pm.project FROM ProjectMember pm WHERE pm.member.id = :memberId")
+    List<Project> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/repository/ProjectMemberRepository.java
@@ -27,6 +27,6 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE p = :project AND m != :author")
     List<ProjectMember> findWithProjectAndNotAuthorByIds(@Param("project") Project project, @Param("author") Member author);
 
-    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.member m JOIN FETCH pm.project p WHERE pm.member.id = :memberId")
-    List<ProjectMember> findByMemberId(@Param("memberId") Long memberId);
+    @Query("SELECT p FROM ProjectMember pm JOIN pm.project p LEFT JOIN FETCH p.techStack WHERE pm.member.id = :memberId")
+    List<Project> findByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #23 
## 작업 내용 📋
- id를 통한 회원 정보 조회 api 구현
- 프로필 페이지에 필요한 정보 조회 api 구현
- 회원 정보, 간략화된 블로그 글 작성 정보, 간략화된 프로젝트 정보
- 간략화된 블로그 및 프로젝트 정보에 대한 DTO 클래스 추가,
controller, service, repository에 관련 코드 추가
 
## 스크린샷 (선택) 📸
회원 정보 조회: localhost:8080/api/members/{id}
<img width="685" height="284" alt="image" src="https://github.com/user-attachments/assets/243632c9-e8bd-4c28-990e-19fff4bd4234" />

프로필 정보 조회: localhost:8080/api/members/profile/{id}
<img width="646" height="769" alt="image" src="https://github.com/user-attachments/assets/83eb78e4-91e8-434c-b1e6-99b3e680a4b7" />
 
## 기타 🔥

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
