### PR TITLE
[refactor] 블로그 상세조회 응답 DTO에 수정 가능 여부 반환 & @UserId 관련 수정 / #64

### DIFF
--- a/src/main/java/dev/woori/wooriLog/domain/blog/controller/BlogController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/controller/BlogController.java
@@ -10,10 +10,14 @@ import dev.woori.wooriLog.global.response.BaseResponse;
 import dev.woori.wooriLog.global.response.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
 
+
+@Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -40,9 +44,10 @@ public class BlogController {
 
     @GetMapping("/blog/{postId}")
     public ResponseEntity<BaseResponse<?>> getBlogInfo(
+            @UserId Optional<Long> userId,
             @PathVariable("postId") Long postId
     ) {
-        BlogDetailInfoRes res = blogService.getBlogInfo(postId);
+        BlogDetailInfoRes res = blogService.getBlogInfo(userId, postId);
         return ApiResponseUtil.success(SuccessCode.OK, res);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogDetailInfoRes.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogDetailInfoRes.java
@@ -7,16 +7,19 @@ import lombok.Builder;
 
 @Builder
 public record BlogDetailInfoRes(
+        boolean isAuthor,
         BlogDto post,
         BlogProjectDto project,
         MemberInfoDto author
 ) {
     public static BlogDetailInfoRes create(
+            boolean isAuthor,
             BlogDto post,
             BlogProjectDto project,
             MemberInfoDto author
     ) {
         return BlogDetailInfoRes.builder()
+                .isAuthor(isAuthor)
                 .post(post)
                 .project(project)
                 .author(author)

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static dev.woori.wooriLog.global.response.error.ErrorMessage.*;
 
@@ -72,16 +73,18 @@ public class BlogService {
      * @return BlogDetailInfoRes: 열람할 글, 작성자, 작성 프로젝트의 정보
      */
     @Transactional
-    public BlogDetailInfoRes getBlogInfo(Long postId) {
+    public BlogDetailInfoRes getBlogInfo(Optional<Long> memberId, Long postId) {
         log.info("[Blog Service] Get Blog Info : blogId={}", postId);
-
+        log.info("{}", memberId);
         Blog blog = blogRepository.findBlogByIdWithDetails(postId)
                 .orElseThrow(() -> new EntityNotFoundException(BLOG_NOT_FOUND));
 
         Project project = blog.getProject();
         Member author = blog.getMember();
+        boolean isAuthor = checkAuthor(memberId, author.getId());
 
         return BlogDetailInfoRes.create(
+                isAuthor,
                 BlogDto.create(blog),
                 createBlogProjectDTO(project, author),
                 MemberInfoDto.create(author)
@@ -116,5 +119,16 @@ public class BlogService {
                 .toList();
 
         return BlogProjectDto.create(project, memberList);
+    }
+
+    /**
+     * 글의 작성자인지 확인하는 메서드
+     * @param memberId 조회한 유저의 memberId
+     * @param authorId 작성자의 memberId
+     * @return boolean 조회한 클라이언트가 작성자인지 여부
+     */
+    private static boolean checkAuthor(Optional<Long> memberId, Long authorId) {
+        log.info("memberId={} authorId={}", memberId, authorId);
+        return memberId.filter(id -> id == authorId).isPresent();
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -127,6 +127,6 @@ public class BlogService {
      * @return boolean 조회한 클라이언트가 작성자인지 여부
      */
     private static boolean checkAuthor(Optional<Long> memberId, Long authorId) {
-        return memberId.filter(id -> id == authorId).isPresent();
+        return memberId.filter(id -> id.equals(authorId)).isPresent();
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -75,7 +75,6 @@ public class BlogService {
     @Transactional
     public BlogDetailInfoRes getBlogInfo(Optional<Long> memberId, Long postId) {
         log.info("[Blog Service] Get Blog Info : blogId={}", postId);
-        log.info("{}", memberId);
         Blog blog = blogRepository.findBlogByIdWithDetails(postId)
                 .orElseThrow(() -> new EntityNotFoundException(BLOG_NOT_FOUND));
 
@@ -128,7 +127,6 @@ public class BlogService {
      * @return boolean 조회한 클라이언트가 작성자인지 여부
      */
     private static boolean checkAuthor(Optional<Long> memberId, Long authorId) {
-        log.info("memberId={} authorId={}", memberId, authorId);
         return memberId.filter(id -> id == authorId).isPresent();
     }
 }

--- a/src/main/java/dev/woori/wooriLog/global/config/SecurityConfig.java
+++ b/src/main/java/dev/woori/wooriLog/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
                             .requestMatchers(whiteList.toArray(new String[0])).permitAll()
                             .anyRequest().authenticated()
                     )
-                    .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                    .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, whiteList), UsernamePasswordAuthenticationFilter.class)
                     .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                     .build();
         }

--- a/src/main/java/dev/woori/wooriLog/global/config/SecurityConfig.java
+++ b/src/main/java/dev/woori/wooriLog/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
                             .requestMatchers(whiteList.toArray(new String[0])).permitAll()
                             .anyRequest().authenticated()
                     )
-                    .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, whiteList), UsernamePasswordAuthenticationFilter.class)
+                    .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                     .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                     .build();
         }

--- a/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,8 @@ package dev.woori.wooriLog.global.filter;
 import dev.woori.wooriLog.global.auth.Constants;
 import dev.woori.wooriLog.global.auth.jwt.JwtProvider;
 import dev.woori.wooriLog.global.auth.jwt.TokenAuthentication;
+import dev.woori.wooriLog.global.exception.JwtTokenException;
+import dev.woori.wooriLog.global.response.error.ErrorBaseCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,10 +12,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 import static dev.woori.wooriLog.global.auth.jwt.TokenAuthentication.createTokenAuthentication;
 
@@ -24,6 +28,8 @@ import static dev.woori.wooriLog.global.auth.jwt.TokenAuthentication.createToken
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final List<String> whiteList;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -33,14 +39,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final boolean isPermitAll = isPermit(request);
         final String accessToken = getAccessToken(request);
-
-        if (accessToken != null) {
-            final long userId = jwtProvider.getUserIdFromClaims(accessToken);
-            // Token을 이용한 인증 객체 생성
-            doAuthentication(accessToken, userId);
+        // 화이트리스트 URI의 경우 통과
+        if (isPermitAll) {
+            if (accessToken != null) {
+                final long userId = jwtProvider.getUserIdFromClaims(accessToken);
+                doAuthentication(accessToken, userId);
+            }
+            filterChain.doFilter(request, response);
+            return;
         }
-
+        // 화이트리스트가 아닌 경우 token이 존재하지 않으면 UNAUTHORIZED 예외 처리
+        if (accessToken == null) {
+            throw new JwtTokenException(ErrorBaseCode.UNAUTHORIZED);
+        }
+        final long userId = jwtProvider.getUserIdFromClaims(accessToken);
+        doAuthentication(accessToken, userId);
         filterChain.doFilter(request, response);
     }
 
@@ -57,5 +72,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         TokenAuthentication tokenAuthentication = createTokenAuthentication(token, userId);
         SecurityContext securityContext = SecurityContextHolder.getContext();
         securityContext.setAuthentication(tokenAuthentication);
+    }
+
+    private boolean isPermit(final HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        if ("GET".equalsIgnoreCase(request.getMethod())) {
+            if (pathMatcher.match("/api/projects/list", uri)) {
+                return false;
+            }
+            if (pathMatcher.match("/api/projects/*", uri) || pathMatcher.match("/api/blog/*", uri)) {
+                return true;
+            }
+        }
+        return whiteList.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
     }
 }

--- a/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
@@ -24,6 +25,7 @@ import static dev.woori.wooriLog.global.auth.jwt.TokenAuthentication.createToken
 /**
  * SpringSecurity FilterChain에 추가할 JWT 관련 Filter
  */
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -44,8 +46,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 화이트리스트 URI의 경우 통과
         if (isPermitAll) {
             if (accessToken != null) {
-                final long userId = jwtProvider.getUserIdFromClaims(accessToken);
-                doAuthentication(accessToken, userId);
+                try {
+                    final long userId = jwtProvider.getUserIdFromClaims(accessToken);
+                    doAuthentication(accessToken, userId);
+                } catch (JwtTokenException e) {
+                    // 유효하지 않은 토큰의 경우 catch문에 잡혀 Authentication을 생성하지 않음
+                    log.warn("[JwtAuthenticationFilter] Invalid JwtToken from Anonymous User", e);
+                }
             }
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/dev/woori/wooriLog/global/filter/JwtAuthenticationFilter.java
@@ -3,8 +3,6 @@ package dev.woori.wooriLog.global.filter;
 import dev.woori.wooriLog.global.auth.Constants;
 import dev.woori.wooriLog.global.auth.jwt.JwtProvider;
 import dev.woori.wooriLog.global.auth.jwt.TokenAuthentication;
-import dev.woori.wooriLog.global.exception.JwtTokenException;
-import dev.woori.wooriLog.global.response.error.ErrorBaseCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,12 +10,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
 
 import static dev.woori.wooriLog.global.auth.jwt.TokenAuthentication.createTokenAuthentication;
 
@@ -28,38 +24,23 @@ import static dev.woori.wooriLog.global.auth.jwt.TokenAuthentication.createToken
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final List<String> whiteList;
-    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            return true;
-        }
-
-        String uri = request.getRequestURI();
-
-        if ("GET".equalsIgnoreCase(request.getMethod())) {
-            if (pathMatcher.match("/api/projects/list", uri)) {
-                return false;
-            }
-            if (pathMatcher.match("/api/projects/*", uri) || pathMatcher.match("/api/blog/*", uri)) {
-                return true;
-            }
-        }
-
-        return whiteList.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
+        // CORS preflight 스킵
+        return "OPTIONS".equalsIgnoreCase(request.getMethod());
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String accessToken = getAccessToken(request);
 
-        final long userId = jwtProvider.getUserIdFromClaims(accessToken);
+        if (accessToken != null) {
+            final long userId = jwtProvider.getUserIdFromClaims(accessToken);
+            // Token을 이용한 인증 객체 생성
+            doAuthentication(accessToken, userId);
+        }
 
-        // Token을 이용한 인증 객체 생성
-        doAuthentication(accessToken, userId);
         filterChain.doFilter(request, response);
     }
 
@@ -69,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Bearer를 제외한 순수 aT
             return accessToken.substring(Constants.BEARER.length());
         }
-        throw new JwtTokenException(ErrorBaseCode.UNAUTHORIZED);
+        return null; // 토큰이 없는 익명 사용자
     }
 
     private void doAuthentication(final String token, final long userId) {

--- a/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
+++ b/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
@@ -1,6 +1,9 @@
 package dev.woori.wooriLog.global.resolver;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -8,12 +11,15 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.util.Optional;
+
+@Slf4j
 @Component
 public class UserIdResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return (parameter.getParameterType().equals(Long.class) || parameter.getParameterType().equals(long.class))
+        return (parameter.getParameterType().equals(Long.class) || parameter.getParameterType().equals(Optional.class))
                 && parameter.hasParameterAnnotation(UserId.class);
     }
 
@@ -22,6 +28,21 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        boolean authenticated = authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken)
+                && authentication != null;
+
+        Long userId = authenticated
+                ? (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal()
+                : null;
+
+        // 익명 사용자
+        if (parameter.getParameterType().equals(Optional.class)) {
+            return Optional.ofNullable(userId);
+        }
+
         return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     }
 }

--- a/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
+++ b/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
@@ -35,7 +35,7 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                 && !(authentication instanceof AnonymousAuthenticationToken);
 
         Long userId = authenticated
-                ? (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal()
+                ? (Long) authentication.getPrincipal()
                 : null;
 
         // 익명 사용자

--- a/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
+++ b/src/main/java/dev/woori/wooriLog/global/resolver/UserIdResolver.java
@@ -30,9 +30,9 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                                   WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        boolean authenticated = authentication.isAuthenticated()
-                && !(authentication instanceof AnonymousAuthenticationToken)
-                && authentication != null;
+        boolean authenticated = authentication != null
+                && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken);
 
         Long userId = authenticated
                 ? (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal()
@@ -43,6 +43,6 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
             return Optional.ofNullable(userId);
         }
 
-        return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userId;
     }
 }


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #64 
## 작업 내용 📋

- 블로그 상세 조회시 수정 가능 여부(boolean) 반환
- 익명 사용자의 인가 처리를 JwtAuthenticationFilter를 httpSecurity로 위임
- 익명사용자가 화이트리스트에 의해 필터되지 않고 넘어온 case에 대해 인증 객체의 userId 처리
- @UserId가 Optional을 반환 할 수 있도록 하여 nullable함을 명시

## 스크린샷 (선택) 📸
 
## 기타 🔥
- @UserId가 nullable한 경우는 화이트리스트에 존재하는 URI에 대한 요청에만 가능하므로 해당 엔드포인트를 사용하는 Controller에서만 Optional을 사용하도록 해야 함.

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
