### PR TITLE
[feat] 구글 API를 이용한 유저 프로필 이미지 조회 및 저장 / #78

### DIFF
--- a/src/main/java/dev/woori/wooriLog/domain/blog/controller/BlogController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/controller/BlogController.java
@@ -25,11 +25,13 @@ public class BlogController {
 
     private final BlogService blogService;
 
+    // 최신 5개의 블로그 조회 (홈화면)
     @GetMapping("/blog/home")
     public ResponseEntity<BaseResponse<?>> getHomeBlogInfos() {
         return ApiResponseUtil.success(SuccessCode.OK, blogService.getBlogBasicInfos());
     }
 
+    // 블로그 작성
     @PostMapping("/blog/{projectId}")
     public ResponseEntity<BaseResponse<?>> createBlog(
             @PathVariable("projectId") Long projectId,
@@ -42,6 +44,7 @@ public class BlogController {
         );
     }
 
+    // 블로그 조회
     @GetMapping("/blog/{postId}")
     public ResponseEntity<BaseResponse<?>> getBlogInfo(
             @UserId Optional<Long> userId,
@@ -51,11 +54,13 @@ public class BlogController {
         return ApiResponseUtil.success(SuccessCode.OK, res);
     }
 
+    // 블로그 수정
     @PutMapping("/blog/{postId}")
     public ResponseEntity<BaseResponse<?>> updateBlog(@UserId Long userId, @PathVariable("postId") Long postId, @Valid @RequestBody BlogCreateOrUpdateReq request){
         return ApiResponseUtil.success(SuccessCode.OK, blogService.updateBlog(userId, postId, request));
     }
 
+    // 블로그 삭제
     @DeleteMapping("/blog/{postId}")
     public ResponseEntity<BaseResponse<?>> deleteBlog(@UserId Long userId, @PathVariable("postId") Long postId) {
         blogService.deleteBlog(userId, postId);

--- a/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogBasicInfoRes.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/dto/response/BlogBasicInfoRes.java
@@ -4,6 +4,7 @@ import dev.woori.wooriLog.domain.blog.dto.request.ProgressDto;
 import dev.woori.wooriLog.domain.blog.entity.Blog;
 import dev.woori.wooriLog.domain.blog.entity.Progress;
 import dev.woori.wooriLog.domain.blog.enums.Category;
+import dev.woori.wooriLog.domain.member.entity.Member;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ public record BlogBasicInfoRes(
         String title,
         String projectName,
         String authorName,
+        String authorProfileUrl,
         Category category,
         List<String> tags,
         List<ProgressDto> progresses,
@@ -22,11 +24,14 @@ public record BlogBasicInfoRes(
         LocalDateTime updatedAt
 ) {
     public static BlogBasicInfoRes create(Blog blog) {
+        Member author = blog.getMember();
+
         return BlogBasicInfoRes.builder()
                 .blogId(blog.getId())
                 .title(blog.getTitle())
                 .projectName(blog.getProject().getProjectName())
-                .authorName(blog.getMember().getName())
+                .authorName(author.getName())
+                .authorProfileUrl(author.getProfileUrl())
                 .category(blog.getCategory())
                 .tags(blog.getTags())
                 .progresses(transProgressDtos(blog.getProgresses()))

--- a/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/controller/MemberController.java
@@ -17,21 +17,25 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // 이메일을 이용한 유저 검색
     @GetMapping("/members/search")
     public ResponseEntity<?> getMembersInfoByEmail(@RequestParam String email, @UserId Long memberId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.findMembersByEmail(email, memberId));
     }
 
+    // 유저 조회
     @GetMapping("/members")
     public ResponseEntity<?> getMemberInfoById(@UserId Long userId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.getMemberInfo(userId));
     }
 
+    // 유저 프로필 조회
     @GetMapping("/members/profile")
     public ResponseEntity<?> getProfileInfoById(@UserId Long userId) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.getProfileInfoById(userId));
     }
 
+    // 유저 프로필 수정
     @PutMapping("/members/profile")
     public ResponseEntity<?> updateMemberInfo(@UserId Long userId, @Valid @RequestBody MemberUpdateReq request) {
         return ApiResponseUtil.success(SuccessCode.OK, memberService.updateMemberInfo(userId, request));

--- a/src/main/java/dev/woori/wooriLog/domain/member/dto/MemberInfoDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/dto/MemberInfoDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record MemberInfoDto(
         Long userId,
+        String profileUrl,
         String email,
         String name,
         String introduce
@@ -13,6 +14,7 @@ public record MemberInfoDto(
     public static MemberInfoDto create(Member member) {
         return MemberInfoDto.builder()
                 .userId(member.getId())
+                .profileUrl(member.getProfileUrl())
                 .email(member.getEmail())
                 .name(member.getName())
                 .introduce(member.getIntroduce())

--- a/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/dto/ProfileDto.java
@@ -11,25 +11,23 @@ import java.util.List;
 
 @Builder
 public record ProfileDto(
-        Long userId,
-        String email,
-        String name,
-        String introduce,
+        MemberInfoDto member,
         List<BlogSummaryDto> blogList,
         List<ProjectBasicInfoDto> projectList
 ) {
     public static ProfileDto create(Member member, List<Blog> blogs, List<Project> projects) {
+        MemberInfoDto memberInfoDto = MemberInfoDto.create(member);
+
         List<BlogSummaryDto> blogSummaryDtos = blogs.stream()
                 .map(BlogSummaryDto::create)
                 .toList();
+
         List<ProjectBasicInfoDto> projectBasicInfoDtos = projects.stream()
                 .map(ProjectBasicInfoDto::create)
                 .toList();
+
         return ProfileDto.builder()
-                .userId(member.getId())
-                .email(member.getEmail())
-                .name(member.getName())
-                .introduce(member.getIntroduce())
+                .member(memberInfoDto)
                 .blogList(blogSummaryDtos)
                 .projectList(projectBasicInfoDtos)
                 .build();

--- a/src/main/java/dev/woori/wooriLog/domain/member/entity/Member.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Getter
@@ -34,14 +35,8 @@ public class Member extends BaseEntity {
 
     private String introduce;
 
-    public static Member create(String email, String name, String provider, String socialId) {
-        return Member.builder()
-                .email(email)
-                .name(name)
-                .provider(provider)
-                .socialId(socialId)
-                .build();
-    }
+    @Column(length = 2048)
+    private String profileUrl;
 
     public static Member create(GoogleUserInfoRes userInfo, GoogleEnrollReq req, String provider) {
         return Member.builder()
@@ -50,6 +45,7 @@ public class Member extends BaseEntity {
                 .provider(provider)
                 .socialId(userInfo.sub())
                 .introduce(req.introduce())
+                .profileUrl(userInfo.picture())
                 .build();
     }
 
@@ -60,5 +56,11 @@ public class Member extends BaseEntity {
 
     public void updateSocialId (String socialId) {
         this.socialId = socialId;
+    }
+
+    public void checkProfile(String picture) {
+        if (this.profileUrl == null || !this.profileUrl.equals(picture)) {
+            this.profileUrl = picture;
+        }
     }
 }

--- a/src/main/java/dev/woori/wooriLog/domain/member/entity/Member.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/entity/Member.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.*;
-import org.hibernate.validator.constraints.Length;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -59,7 +59,7 @@ public class Member extends BaseEntity {
     }
 
     public void checkProfile(String picture) {
-        if (this.profileUrl == null || !this.profileUrl.equals(picture)) {
+        if (!Objects.equals(this.profileUrl, picture)) {
             this.profileUrl = picture;
         }
     }

--- a/src/main/java/dev/woori/wooriLog/domain/project/controller/ProjectController.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/controller/ProjectController.java
@@ -19,11 +19,13 @@ public class ProjectController {
 
     private final ProjectService projectService;
 
+    // 최신 5개의 프로젝트 조회 (홈화면)
     @GetMapping("/projects/home")
     public ResponseEntity<BaseResponse<?>> getHomeProjectInfos() {
         return ApiResponseUtil.success(SuccessCode.OK, projectService.getProjectBasicInfos());
     }
 
+    // 프로젝트 생성
     @PostMapping("/projects")
     public ResponseEntity<BaseResponse<?>> createProject(
             @UserId Long leaderId,
@@ -35,11 +37,13 @@ public class ProjectController {
         );
     }
 
+    // 프로젝트 조회
     @GetMapping("/projects/{projectId}")
     public ResponseEntity<BaseResponse<?>> getProjectInfo(@PathVariable Long projectId) {
         return ApiResponseUtil.success(SuccessCode.OK, projectService.getProjectInfo(projectId));
     }
 
+    // 프로젝트 가입 목록 조회 (유저)
     @GetMapping("/projects/list")
     public ResponseEntity<BaseResponse<?>> getProjectList(@UserId Long memberId) {
         return ApiResponseUtil.success(SuccessCode.OK, projectService.getProjectListByMemberId(memberId));

--- a/src/main/java/dev/woori/wooriLog/global/auth/dto/LoginSuccessRes.java
+++ b/src/main/java/dev/woori/wooriLog/global/auth/dto/LoginSuccessRes.java
@@ -9,6 +9,7 @@ public record LoginSuccessRes(
         Long userId,
         String username,
         String email,
+        String profileUrl,
         String accessToken,
         String refreshToken
 ) {
@@ -17,6 +18,7 @@ public record LoginSuccessRes(
                 .userId(member.getId())
                 .username(member.getName())
                 .email(member.getEmail())
+                .profileUrl(member.getProfileUrl())
                 .accessToken(token.getAccessToken())
                 .refreshToken(token.getRefreshToken())
                 .build();

--- a/src/main/java/dev/woori/wooriLog/global/auth/service/GoogleOAuthService.java
+++ b/src/main/java/dev/woori/wooriLog/global/auth/service/GoogleOAuthService.java
@@ -42,6 +42,9 @@ public class GoogleOAuthService {
         Member member = memberRepository.findByProviderAndSocialId(Constants.GOOGLE, userInfo.sub()) // 소셜 ID를 통한 유저 조회
                 .orElseThrow(() -> new UnEnrolledException(googleToken.access_token()));
 
+        // 프로필 이미지 변경시 변경사항 적용
+        member.checkProfile(userInfo.picture());
+
         // JWT Token 발급
         Token token = jwtProvider.issueToken(member.getId());
 


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #78 
## 작업 내용 📋

- 구글 UserInfo API에서 Scope를 확장하여 프로필 이미지 조회
- 프로필 이미지를 Member 엔티티에 추가하여 저장
- 유저 정보 관련 DTO 필드에 유저 프로필 이미지 url 추가
- 각 컨트롤러에서 엔드포인트 설명 주석 추가
 
## 스크린샷 (선택) 📸
 
## 기타 🔥

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
