### PR TITLE
[refactor] 회원가입시 인메모리 캐시와 티켓을 이용하여 Token을 추출하도록 하여 보안 문제 해결 / #65

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security' // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // OAuth2
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // Feign

--- a/src/main/java/dev/woori/wooriLog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/dev/woori/wooriLog/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByEmailContainingAndIdNot(String email, Long id);
     
     boolean existsMemberByEmail(String email);
+
+    boolean existsMemberByProviderAndSocialId(String provider, String socialId);
 }

--- a/src/main/java/dev/woori/wooriLog/global/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriLog/global/auth/controller/AuthController.java
@@ -24,9 +24,9 @@ public class AuthController {
 
     @PostMapping("/google/enroll")
     public ResponseEntity<BaseResponse<?>> googleEnroll(
-            @RequestHeader(name = "Authorization") String googleToken ,
+            @RequestHeader(name = "Authorization") String ticket,
             @Valid  @RequestBody GoogleEnrollReq request
     ) {
-        return ApiResponseUtil.success(SuccessCode.OK, googleOAuthService.enroll(googleToken, request));
+        return ApiResponseUtil.success(SuccessCode.OK, googleOAuthService.enroll(ticket, request));
     }
 }

--- a/src/main/java/dev/woori/wooriLog/global/auth/service/GoogleOAuthService.java
+++ b/src/main/java/dev/woori/wooriLog/global/auth/service/GoogleOAuthService.java
@@ -7,14 +7,20 @@ import dev.woori.wooriLog.global.auth.dto.*;
 import dev.woori.wooriLog.global.auth.feign.FeignProvider;
 import dev.woori.wooriLog.global.auth.jwt.JwtProvider;
 import dev.woori.wooriLog.global.auth.jwt.Token;
+import dev.woori.wooriLog.global.cache.EnrollCache;
 import dev.woori.wooriLog.global.exception.UnEnrolledException;
 import dev.woori.wooriLog.global.exception.WooriLogUseException;
 import dev.woori.wooriLog.global.response.error.ErrorBaseCode;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+import static dev.woori.wooriLog.global.response.error.ErrorMessage.*;
 
 
 @Slf4j
@@ -25,6 +31,7 @@ public class GoogleOAuthService {
     private final FeignProvider feignProvider;
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+    private final EnrollCache enrollCache;
 
     /**
      * 로그인 로직
@@ -39,9 +46,14 @@ public class GoogleOAuthService {
         GoogleTokenRes googleToken = feignProvider.getGoogleToken(request.authorizationCode());
         GoogleUserInfoRes userInfo = getUserInfo(googleToken.access_token());
 
-        // Member 조회 or 생성
+        // 회원가입 필요
+        if (!memberRepository.existsMemberByProviderAndSocialId(Constants.GOOGLE, userInfo.sub())) {
+            String ticket = issueTicket(googleToken.access_token());
+            throw new UnEnrolledException(ticket);
+        }
+
         Member member = memberRepository.findByProviderAndSocialId(Constants.GOOGLE, userInfo.sub()) // 소셜 ID를 통한 유저 조회
-                .orElseThrow(() -> new UnEnrolledException(googleToken.access_token()));
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
         // 프로필 이미지 변경시 변경사항 적용
         member.checkProfile(userInfo.picture());
@@ -58,8 +70,15 @@ public class GoogleOAuthService {
      * @return LoginSuccessRes
      */
     @Transactional
-    public LoginSuccessRes enroll(final String accessToken, GoogleEnrollReq request) {
+    public LoginSuccessRes enroll(String ticket, GoogleEnrollReq request) {
         log.info("[Auth Service] Member Enroll : request={}", request);
+
+        if (isStartWithBearer(ticket)) {
+            ticket = ticket.replace(Constants.BEARER, "");
+        }
+
+        String accessToken = enrollCache.findAndConsume(ticket)
+                .orElseThrow(() -> new IllegalArgumentException(INVALID_TOKEN));
 
         GoogleUserInfoRes userInfo = getUserInfo(accessToken);
         isEnrolled(userInfo.email());
@@ -76,7 +95,7 @@ public class GoogleOAuthService {
      * @return GoogleUserInfoRes 구글에서 전달받은 유저정보
      */
     private GoogleUserInfoRes getUserInfo(String accessToken) {
-        if (StringUtils.hasText(accessToken) && !accessToken.startsWith(Constants.BEARER))
+        if (!isStartWithBearer(accessToken))
             accessToken = Constants.BEARER + accessToken;
         return feignProvider.getUserInfo(accessToken);
     }
@@ -85,5 +104,15 @@ public class GoogleOAuthService {
         if (memberRepository.existsMemberByEmail(email)) {
             throw new WooriLogUseException(ErrorBaseCode.CONFLICT);
         }
+    }
+
+    private String issueTicket(String accessToken) {
+        String ticket = UUID.randomUUID().toString();
+        enrollCache.save(ticket, accessToken);
+        return ticket;
+    }
+
+    private static boolean isStartWithBearer(String header) {
+        return StringUtils.hasText(header) && header.startsWith(Constants.BEARER);
     }
 }

--- a/src/main/java/dev/woori/wooriLog/global/cache/EnrollCache.java
+++ b/src/main/java/dev/woori/wooriLog/global/cache/EnrollCache.java
@@ -1,0 +1,11 @@
+package dev.woori.wooriLog.global.cache;
+
+import java.util.Optional;
+
+// 추후 Redis 등 확장성을 위해 인터페이스 사용
+public interface EnrollCache {
+
+    void save(String ticket, String accessToken);
+
+    Optional<String> findAndConsume(String ticket);
+}

--- a/src/main/java/dev/woori/wooriLog/global/cache/InMemoryEnrollCache.java
+++ b/src/main/java/dev/woori/wooriLog/global/cache/InMemoryEnrollCache.java
@@ -1,0 +1,31 @@
+package dev.woori.wooriLog.global.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class InMemoryEnrollCache implements EnrollCache{
+
+    private final Cache<String, String> cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(10))
+            .maximumSize(1000)
+            .build();
+
+    @Override
+    public void save(String ticket, String accessToken) {
+        cache.put(ticket, accessToken);
+    }
+
+    @Override
+    public Optional<String> findAndConsume(String ticket) {
+        ConcurrentMap<String, @NonNull String> tokenMap = cache.asMap();
+        String accessToken = tokenMap.remove(ticket);
+        return Optional.ofNullable(accessToken);
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/global/response/error/ErrorMessage.java
+++ b/src/main/java/dev/woori/wooriLog/global/response/error/ErrorMessage.java
@@ -20,6 +20,7 @@ public abstract class ErrorMessage {
      */
     public static final String INVALID_MEMBER_EMAIL = "멤버의 이메일이 올바르지 않습니다 : ";
     public static final String DUPLICATED_REQUEST = "이미 존재하는 리소스 입니다.";
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 
     /**
      * DENIED - 접근 거부


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #65 
## 작업 내용 📋

- Caffeine Cache 라이브러리 추가 (추후 홈 화면 관련 API에서도 캐시 사용을 위해 라이브러리 사용을 선택)
- 로그인 시 회원가입이 필요한 유저의 경우 티켓을 발급하여, 회원가입시 티켓을 헤더에 담아 요청하도록 수정
✅ 기존 GoogleToken을 노출하던 보안 문제 해결
 
## 스크린샷 (선택) 📸
 
## 기타 🔥

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
