### PR TITLE
홈화면 조회 관련 API에 인메모리 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // OAuth2
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign' // Feign

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -13,6 +13,7 @@ import dev.woori.wooriLog.domain.member.entity.Member;
 import dev.woori.wooriLog.domain.project.entity.Project;
 import dev.woori.wooriLog.domain.project.entity.ProjectMember;
 import dev.woori.wooriLog.domain.project.repository.ProjectMemberRepository;
+import dev.woori.wooriLog.global.cache.CacheNames;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +46,7 @@ public class BlogService {
      * @param request 새로운 글의 데이터가 담긴 request
      */
     @Transactional
-    @CacheEvict(value = "home-blogs", allEntries = true)
+    @CacheEvict(value = CacheNames.HOME_BLOGS, allEntries = true)
     public Long createBlog(Long projectId, Long userId, BlogCreateOrUpdateReq request) {
         log.info("[Blog Service] Create Blog : projectId={}, userId={}", projectId, userId);
         // 프로젝트-멤버 관계 조회
@@ -95,7 +96,7 @@ public class BlogService {
      * 홈 화면에 전달할 최신 5개 블로그 기본 정보 반환 메서드
      * @return List<BlogBasicInfoRes>
      */
-    @Cacheable(value = "home-blogs")
+    @Cacheable(value = CacheNames.HOME_BLOGS)
     public List<BlogBasicInfoRes> getBlogBasicInfos() {
         log.info("[Blog Service] getBlogBasicInfos");
         List<Blog> top5OrderByCreatedAtDesc =
@@ -115,7 +116,7 @@ public class BlogService {
      * @return blogId 블로그 id
      */
     @Transactional
-    @CacheEvict(value = "home-blogs", allEntries = true)
+    @CacheEvict(value = CacheNames.HOME_BLOGS, allEntries = true)
     public Long updateBlog(Long userId, Long blogId, BlogCreateOrUpdateReq request) {
         log.info("[Blog Service] Update Blog : blogId={}", blogId);
         Blog blog = findBlogAndCheckOwnerShip(userId, blogId);
@@ -131,7 +132,7 @@ public class BlogService {
      * @param blogId 블로그 id
      */
     @Transactional
-    @CacheEvict(value = "home-blogs", allEntries = true)
+    @CacheEvict(value = CacheNames.HOME_BLOGS, allEntries = true)
     public void deleteBlog(Long userId, Long blogId) {
         log.info("[Blog Service] Delete Blog : blogId={}", blogId);
         Blog blog = findBlogAndCheckOwnerShip(userId, blogId);

--- a/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/blog/service/BlogService.java
@@ -16,6 +16,8 @@ import dev.woori.wooriLog.domain.project.repository.ProjectMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,7 @@ public class BlogService {
      * @param request 새로운 글의 데이터가 담긴 request
      */
     @Transactional
+    @CacheEvict(value = "home-blogs", allEntries = true)
     public Long createBlog(Long projectId, Long userId, BlogCreateOrUpdateReq request) {
         log.info("[Blog Service] Create Blog : projectId={}, userId={}", projectId, userId);
         // 프로젝트-멤버 관계 조회
@@ -92,6 +95,7 @@ public class BlogService {
      * 홈 화면에 전달할 최신 5개 블로그 기본 정보 반환 메서드
      * @return List<BlogBasicInfoRes>
      */
+    @Cacheable(value = "home-blogs")
     public List<BlogBasicInfoRes> getBlogBasicInfos() {
         log.info("[Blog Service] getBlogBasicInfos");
         List<Blog> top5OrderByCreatedAtDesc =
@@ -103,22 +107,6 @@ public class BlogService {
     }
 
     /**
-     * 열람할 글을 작성한 프로젝트에 대한 DTO를 생성해 리턴합니다.
-     *
-     * @param project 열람할 글을 작성한 프로젝트의 엔티티
-     * @return BlogProjectDto: 열람할 글을 작성한 프로젝트의 DTO
-     */
-    private BlogProjectDto createBlogProjectDTO(Project project, Member author) {
-        List<ProjectMember> projectMember = projectMemberRepository.findWithProjectAndNotAuthorByIds(project, author);
-
-        List<MemberInfoDto> memberList = projectMember.stream()
-                .map(pm -> MemberInfoDto.create(pm.getMember()))
-                .toList();
-
-        return BlogProjectDto.create(project, memberList);
-    }
-
-    /**
      * 블로그 id와 수정된 블로그 포스팅 정보를 통해 블로그 글을 수정
      * 블로그 글 작성자 id와 요청을 보낸 사용자 id가 일치하지 않으면 예외 발생
      * @param userId 사용자 id
@@ -127,6 +115,7 @@ public class BlogService {
      * @return blogId 블로그 id
      */
     @Transactional
+    @CacheEvict(value = "home-blogs", allEntries = true)
     public Long updateBlog(Long userId, Long blogId, BlogCreateOrUpdateReq request) {
         log.info("[Blog Service] Update Blog : blogId={}", blogId);
         Blog blog = findBlogAndCheckOwnerShip(userId, blogId);
@@ -142,6 +131,7 @@ public class BlogService {
      * @param blogId 블로그 id
      */
     @Transactional
+    @CacheEvict(value = "home-blogs", allEntries = true)
     public void deleteBlog(Long userId, Long blogId) {
         log.info("[Blog Service] Delete Blog : blogId={}", blogId);
         Blog blog = findBlogAndCheckOwnerShip(userId, blogId);
@@ -160,6 +150,22 @@ public class BlogService {
             throw new AccessDeniedException(BLOG_ACCESS_DENIED);
         }
         return blog;
+    }
+
+    /**
+     * 열람할 글을 작성한 프로젝트에 대한 DTO를 생성해 리턴합니다.
+     *
+     * @param project 열람할 글을 작성한 프로젝트의 엔티티
+     * @return BlogProjectDto: 열람할 글을 작성한 프로젝트의 DTO
+     */
+    private BlogProjectDto createBlogProjectDTO(Project project, Member author) {
+        List<ProjectMember> projectMember = projectMemberRepository.findWithProjectAndNotAuthorByIds(project, author);
+
+        List<MemberInfoDto> memberList = projectMember.stream()
+                .map(pm -> MemberInfoDto.create(pm.getMember()))
+                .toList();
+
+        return BlogProjectDto.create(project, memberList);
     }
 
     /**

--- a/src/main/java/dev/woori/wooriLog/domain/project/service/ProjectService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/service/ProjectService.java
@@ -19,6 +19,8 @@ import dev.woori.wooriLog.domain.project.repository.ProjectRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -52,6 +54,7 @@ public class ProjectService {
      * @param request 프로젝트 생성 요청 DTO
      */
     @Transactional
+    @CacheEvict(value = "home-projects", allEntries = true)
     public Long createProject(Long leaderId, ProjectCreateReq request) {
         log.info("[Project Service] Create Project");
         // 프로젝트 생성
@@ -72,7 +75,6 @@ public class ProjectService {
      * @param projectId 프로젝트 Id
      * @return ProjectInfoRes
      */
-    @Transactional
     public ProjectInfoRes getProjectInfo(Long projectId) {
         log.info("[Project Service] getProjectInfo : projectId={}", projectId);
 
@@ -116,6 +118,7 @@ public class ProjectService {
      * 홈 화면에 전달할 최신 5개 프로젝트 기본 정보 반환 메서드
      * @return List<ProjectBasicInfoDto>
      */
+    @Cacheable(value = "home-projects")
     public List<ProjectBasicInfoDto> getProjectBasicInfos() {
         log.info("[Project Service] getProjectBasicInfos");
 
@@ -140,6 +143,7 @@ public class ProjectService {
      * @param leaderId 요청 유저 ID
      */
     @Transactional
+    @CacheEvict(value = "home-projects", allEntries = true)
     public void deleteProject(Long projectId, Long leaderId) {
         Project project = findProjectBy(projectId);
         // TODO : Spring Interceptor를 적용하여 추후 분리

--- a/src/main/java/dev/woori/wooriLog/domain/project/service/ProjectService.java
+++ b/src/main/java/dev/woori/wooriLog/domain/project/service/ProjectService.java
@@ -16,6 +16,7 @@ import dev.woori.wooriLog.domain.project.entity.Project;
 import dev.woori.wooriLog.domain.project.entity.ProjectMember;
 import dev.woori.wooriLog.domain.project.repository.ProjectMemberRepository;
 import dev.woori.wooriLog.domain.project.repository.ProjectRepository;
+import dev.woori.wooriLog.global.cache.CacheNames;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,8 +26,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,7 +53,7 @@ public class ProjectService {
      * @param request 프로젝트 생성 요청 DTO
      */
     @Transactional
-    @CacheEvict(value = "home-projects", allEntries = true)
+    @CacheEvict(value = CacheNames.HOME_PROJECTS, allEntries = true)
     public Long createProject(Long leaderId, ProjectCreateReq request) {
         log.info("[Project Service] Create Project");
         // 프로젝트 생성
@@ -118,7 +117,7 @@ public class ProjectService {
      * 홈 화면에 전달할 최신 5개 프로젝트 기본 정보 반환 메서드
      * @return List<ProjectBasicInfoDto>
      */
-    @Cacheable(value = "home-projects")
+    @Cacheable(value = CacheNames.HOME_PROJECTS)
     public List<ProjectBasicInfoDto> getProjectBasicInfos() {
         log.info("[Project Service] getProjectBasicInfos");
 
@@ -143,7 +142,7 @@ public class ProjectService {
      * @param leaderId 요청 유저 ID
      */
     @Transactional
-    @CacheEvict(value = "home-projects", allEntries = true)
+    @CacheEvict(value = CacheNames.HOME_PROJECTS, allEntries = true)
     public void deleteProject(Long projectId, Long leaderId) {
         Project project = findProjectBy(projectId);
         // TODO : Spring Interceptor를 적용하여 추후 분리

--- a/src/main/java/dev/woori/wooriLog/global/cache/CacheNames.java
+++ b/src/main/java/dev/woori/wooriLog/global/cache/CacheNames.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriLog.global.cache;
+
+public abstract class CacheNames {
+    public static final String HOME_BLOGS = "home-blogs";
+    public static final String HOME_PROJECTS = "home-projects";
+}

--- a/src/main/java/dev/woori/wooriLog/global/cache/InMemoryEnrollCache.java
+++ b/src/main/java/dev/woori/wooriLog/global/cache/InMemoryEnrollCache.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentMap;
 @Component
 public class InMemoryEnrollCache implements EnrollCache{
 
-    private final Cache<String, String> cache = Caffeine.newBuilder()
+    private final Cache<@NonNull String, String> cache = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofMinutes(10))
             .maximumSize(1000)
             .build();

--- a/src/main/java/dev/woori/wooriLog/global/config/CacheConfig.java
+++ b/src/main/java/dev/woori/wooriLog/global/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package dev.woori.wooriLog.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.NonNull;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public Caffeine<@NonNull Object, @NonNull Object> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(180))
+                .initialCapacity(10)
+                .maximumSize(1000);
+    }
+
+    @Bean
+    public CacheManager cacheManager(Caffeine<@NonNull Object, @NonNull Object> caffeine) {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setCaffeine(caffeine);
+        return manager;
+    }
+}

--- a/src/main/java/dev/woori/wooriLog/global/config/CacheConfig.java
+++ b/src/main/java/dev/woori/wooriLog/global/config/CacheConfig.java
@@ -1,7 +1,7 @@
 package dev.woori.wooriLog.global.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
-import lombok.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;


### PR DESCRIPTION
# *PULL REQUESTS ❤️‍🔥*

## 이슈 번호 📌
- *Resolved* : #90 
## 작업 내용 📋

- CacheConfig 설정 (Caffeine 라이브러리 기반)
- 블로그 조회 (홈화면) 서비스에 Cache 적용 / 쓰기 작업시 캐시 해제 
- 프로젝트 조회 (홈화면) 서비스에 Cache 적용 / 쓰기 작업시 캐시 해제 

## 스크린샷 (선택) 📸
 
## 기타 🔥

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] 로컬에서 테스트 하셨나요?
